### PR TITLE
feat: update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chargetrip/types",
-  "version": "2.0.0",
+  "version": "1.11.0",
   "description": "Typescript types for the Chargetrip EV-routing GraphQL API",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Bump version number to 1.11.0. This version contains all of the types for the car improvements release of 27-01-2021.